### PR TITLE
Release 0.8.0: Remove apperate.listDataJobs().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.8.0 / 2022-10-17
+==================
+
+  * Remove apperate.listDataJobs().  Use queryDataJobs() instead.
+
 0.7.0 / 2022-10-17
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apperate/iexjs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "JS interface to IEX and IEX Cloud APIs",
   "repository": {
     "type": "git",

--- a/src/js/apperate/crud_external.js
+++ b/src/js/apperate/crud_external.js
@@ -54,35 +54,6 @@ Client.apperate.prototype.createDataJob = function (options, standardOptions) {
   });
 };
 
-export const listDataJobs = (args, standardOptions) => {
-  const qpNames = ["token"];
-  let url = "jobs";
-  for (const { name, required } of [
-    { name: "workspace", required: true },
-    { name: "type", required: true },
-  ]) {
-    if (name in args) url += "/" + args[name];
-    else if (required) throw IEXJSException(`Must provide '${name}'`);
-    else break;
-  }
-  return _apperateGet({
-    url,
-    queryParams: qpNames,
-    ...Object.fromEntries(
-      qpNames.filter((el) => el in args).map((el) => [el, args[el]])
-    ),
-    ...standardOptions,
-  });
-};
-
-Client.apperate.prototype.listDataJobs = function (options, standardOptions) {
-  return listDataJobs(options, {
-    token: this._token,
-    version: this._version,
-    ...standardOptions,
-  });
-};
-
 export const queryDataJobs = (args, standardOptions) => {
   const qpNames = ["token", "limit", "from", "to", "last", "first", "sort"];
   let url = "jobs";


### PR DESCRIPTION
Use queryDataJobs() instead.